### PR TITLE
Add MONGO_URI to OpenShift cluster

### DIFF
--- a/.github/workflows/deploy-to-openshift.yml
+++ b/.github/workflows/deploy-to-openshift.yml
@@ -41,6 +41,10 @@ jobs:
           namespace: ${{ env.OPENSHIFT_NAMESPACE }}
           port: ${{ env.APP_PORT }}
 
+      - name: Set MongoDB URI 
+        run: |
+          oc set env deployment.apps/backend MONGO_URI=${{ secrets.MONGO_URI }}
+
       - name: Print application URL
         env:
           ROUTE: ${{ steps.deploy-and-expose.outputs.route }}


### PR DESCRIPTION
This commit configures the cluster with the environment variable to
enable it to access the MongoDB database.